### PR TITLE
Push data to clients in SimpleServer CLI

### DIFF
--- a/examples/spray-websocket-simple/src/main/scala/spray/can/websocket/examples/SimpleServer.scala
+++ b/examples/spray-websocket-simple/src/main/scala/spray/can/websocket/examples/SimpleServer.scala
@@ -13,6 +13,7 @@ import spray.routing.HttpServiceActor
 object SimpleServer extends App with MySslConfiguration {
 
   final case class Push(msg: String)
+  final case class PushToChildren(msg: String)
 
   object WebSocketServer {
     def props() = Props(classOf[WebSocketServer])
@@ -24,6 +25,10 @@ object SimpleServer extends App with MySslConfiguration {
         val serverConnection = sender()
         val conn = context.actorOf(WebSocketWorker.props(serverConnection))
         serverConnection ! Http.Register(conn)
+      case PushToChildren(msg: String) =>
+        val children = context.children
+        println("pushing to all children : " + msg)
+        children.foreach(ref => ref ! Push(msg))
     }
   }
 
@@ -62,7 +67,12 @@ object SimpleServer extends App with MySslConfiguration {
 
     IO(UHttp) ! Http.Bind(server, "localhost", 8080)
 
-    scala.io.StdIn.readLine("Hit ENTER to exit ...\n")
+    while (true) {
+      var msg = scala.io.StdIn.readLine("Give a message and hit ENTER to push message to the children ...\n")
+      server ! PushToChildren(msg)
+    }
+
+    // Never reached ...
     system.shutdown()
     system.awaitTermination()
   }


### PR DESCRIPTION
Expand the SimpleServer with a basic example of Pushing a message to the clients from the server.

This is trivial once you get it, but for a newcomer, it is not trivial how the actor system works exactly (with a Server and Workers) and how this should be done.